### PR TITLE
Deploys Cilium CNI for load balancing

### DIFF
--- a/argocd/infra-apps/cilium.yaml
+++ b/argocd/infra-apps/cilium.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igh9410/igh9410-infra.git
+    targetRevision: main
+    path: infrastructure/cilium
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  revisionHistoryLimit: 10

--- a/argocd/values/alloy.yaml
+++ b/argocd/values/alloy.yaml
@@ -272,7 +272,7 @@ controller:
   tolerations:
     - key: "dedicated"
       operator: "Equal"
-      value: "db"
+      value: "prod-database"
       effect: "NoSchedule"
 
   # -- Topology Spread Constraints to apply to Grafana Alloy pods.

--- a/argocd/values/loki.yaml
+++ b/argocd/values/loki.yaml
@@ -1502,7 +1502,11 @@ singleBinary:
   # -- Node selector for single binary pods
   nodeSelector: {}
   # -- Tolerations for single binary pods
-  tolerations: []
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "prod-database"
+      effect: "NoSchedule"
   persistence:
     # -- Enable StatefulSetAutoDeletePVC feature
     enableStatefulSetAutoDeletePVC: true

--- a/infrastructure/cilium/ippool.yaml
+++ b/infrastructure/cilium/ippool.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: "default-pool"
+  namespace: kube-system
+spec:
+  blocks:
+    - cidr: "192.168.45.0/24"
+  serviceSelector:
+    matchLabels:
+      cilium-lb-pool: default-pool

--- a/infrastructure/cilium/kustomization.yaml
+++ b/infrastructure/cilium/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ippool.yaml
+  - l2-announcement.yaml

--- a/infrastructure/cilium/l2-announcement.yaml
+++ b/infrastructure/cilium/l2-announcement.yaml
@@ -6,7 +6,5 @@ spec:
   serviceSelector:
     matchLabels:
       cilium-lb-pool: default-pool
-  interfaces:
-    - ^eth[0-9]+
   externalIPs: true
   loadBalancerIPs: true

--- a/infrastructure/cilium/l2-announcement.yaml
+++ b/infrastructure/cilium/l2-announcement.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: default-l2
+spec:
+  serviceSelector:
+    matchLabels:
+      color: blue
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+  interfaces:
+    - ^eth[0-9]+
+  externalIPs: true
+  loadBalancerIPs: true

--- a/infrastructure/cilium/l2-announcement.yaml
+++ b/infrastructure/cilium/l2-announcement.yaml
@@ -5,11 +5,7 @@ metadata:
 spec:
   serviceSelector:
     matchLabels:
-      color: blue
-  nodeSelector:
-    matchExpressions:
-      - key: node-role.kubernetes.io/control-plane
-        operator: DoesNotExist
+      cilium-lb-pool: default-pool
   interfaces:
     - ^eth[0-9]+
   externalIPs: true


### PR DESCRIPTION
This pull request deploys Cilium CNI to handle load balancing within the cluster.

It introduces:
- Cilium application managed by ArgoCD
- Cilium IP Pool configuration
- L2 Announcement policy

Additionally, it:
- Adds tolerations for alloy and loki pods to schedule on database nodes