### PR TITLE
Configures Cilium for Tailscale integration

### DIFF
--- a/argocd/infra-apps/tailscale-operator.yaml
+++ b/argocd/infra-apps/tailscale-operator.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tailscale-operator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://pkgs.tailscale.com/helmcharts
+      chart: tailscale-operator
+      targetRevision: "1.88.3" # Latest stable version
+      helm:
+        releaseName: tailscale-operator
+        valueFiles:
+          - $values/argocd/values/tailscale-operator.yaml
+    - repoURL: https://github.com/igh9410/igh9410-infra.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tailscale
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+  revisionHistoryLimit: 10

--- a/argocd/values/cilium.yaml
+++ b/argocd/values/cilium.yaml
@@ -5,21 +5,20 @@ hubble:
     enabled: true
   ui:
     enabled: false
+ingressController:
+  default: true
+  enabled: true
+  loadbalancerMode: shared
 ipam:
   operator:
     clusterPoolIPv4PodCIDRList: 192.168.0.0/16
+k8sServiceHost: 192.168.45.199
+k8sServicePort: 6443
+kubeProxyReplacement: true
 l2announcements:
   enabled: true
 operator:
   replicas: 1
-routingMode: tunnel
+routingMode: native
+socketLB.hostNamespaceOnly: true
 tunnelProtocol: vxlan
-kubeProxyReplacement: true
-# Required for bootstrap when kubeProxyReplacement=true
-# Allows Cilium to connect directly to API server instead of service IP
-k8sServiceHost: 192.168.45.199
-k8sServicePort: 6443
-ingressController:
-  enabled: true
-  loadbalancerMode: shared
-  default: true

--- a/argocd/values/tailscale-operator.yaml
+++ b/argocd/values/tailscale-operator.yaml
@@ -1,0 +1,137 @@
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Operator oauth credentials. If set a Kubernetes Secret with the provided
+# values will be created in the operator namespace. If unset a Secret named
+# operator-oauth must be precreated or oauthSecretVolume needs to be adjusted.
+# This block will be overridden by oauthSecretVolume, if set.
+oauth:
+  clientId: ""
+  clientSecret: ""
+
+# URL of the control plane to be used by all resources managed by the operator.
+loginServer: ""
+
+# Secret volume.
+# If set it defines the volume the oauth secrets will be mounted from.
+# The volume needs to contain two files named `client_id` and `client_secret`.
+# If unset the volume will reference the Secret named operator-oauth.
+# This block will override the oauth block.
+oauthSecretVolume:
+  {}
+  # csi:
+  #   driver: secrets-store.csi.k8s.io
+  #   readOnly: true
+  #   volumeAttributes:
+  #     secretProviderClass: tailscale-oauth
+  #
+  ## NAME is pre-defined!
+
+# installCRDs determines whether tailscale.com CRDs should be installed as part
+# of chart installation. We do not use Helm's CRD installation mechanism as that
+# does not allow for upgrading CRDs.
+# https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+installCRDs: true
+
+operatorConfig:
+  # ACL tag that operator will be tagged with. Operator must be made owner of
+  # these tags
+  # https://tailscale.com/kb/1236/kubernetes-operator/?q=operator#setting-up-the-kubernetes-operator
+  # Multiple tags are defined as array items and passed to the operator as a comma-separated string
+  defaultTags:
+    - "tag:k8s-operator"
+
+  image:
+    # Repository defaults to DockerHub, but images are also synced to ghcr.io/tailscale/k8s-operator.
+    repository: tailscale/k8s-operator
+    # Digest will be prioritized over tag. If neither are set appVersion will be
+    # used.
+    tag: ""
+    digest: ""
+    pullPolicy: Always
+  logging: "info" # info, debug, dev
+  hostname: "tailscale-operator"
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  resources: {}
+
+  podAnnotations: {}
+  podLabels: {}
+
+  serviceAccountAnnotations: {}
+  # eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/tailscale-operator-role
+
+  tolerations: []
+
+  affinity: {}
+
+  podSecurityContext: {}
+
+  securityContext: {}
+
+  extraEnv: []
+  # - name: EXTRA_VAR1
+  #   value: "value1"
+  # - name: EXTRA_VAR2
+  #   value: "value2"
+
+# In the case that you already have a tailscale ingressclass in your cluster (or vcluster), you can disable the creation here
+ingressClass:
+  # Allows for customization of the ingress class name used by the operator to identify ingresses to reconcile. This does
+  # not allow multiple operator instances to manage different ingresses, but provides an onboarding route for users that
+  # may have previously set up ingress classes named "tailscale" prior to using the operator.
+  name: "tailscale"
+  enabled: true
+
+# proxyConfig contains configuraton that will be applied to any ingress/egress
+# proxies created by the operator.
+# https://tailscale.com/kb/1439/kubernetes-operator-cluster-ingress
+# https://tailscale.com/kb/1438/kubernetes-operator-cluster-egress
+# Note that this section contains only a few global configuration options and
+# will not be updated with more configuration options in the future.
+# If you need more configuration options, take a look at ProxyClass:
+# https://tailscale.com/kb/1445/kubernetes-operator-customization#cluster-resource-customization-using-proxyclass-custom-resource
+proxyConfig:
+  # Configure the proxy image to use instead of the default tailscale/tailscale:latest.
+  # Applying a ProxyClass with `spec.statefulSet.pod.tailscaleContainer.image`
+  # set will override any defaults here.
+  #
+  # Note that ProxyGroups of type "kube-apiserver" use a different default image,
+  # tailscale/k8s-proxy:latest, and it is currently only possible to override
+  # that image via the same ProxyClass field.
+  image:
+    # Repository defaults to DockerHub, but images are also synced to ghcr.io/tailscale/tailscale.
+    repository: tailscale/tailscale
+    # Digest will be prioritized over tag. If neither are set appVersion will be
+    # used.
+    tag: ""
+    digest: ""
+  # ACL tag that operator will tag proxies with. Operator must be made owner of
+  # these tags
+  # https://tailscale.com/kb/1236/kubernetes-operator/?q=operator#setting-up-the-kubernetes-operator
+  # Multiple tags can be passed as a comma-separated string i.e 'tag:k8s-proxies,tag:prod'.
+  # Note that if you pass multiple tags to this field via `--set` flag to helm upgrade/install commands you must escape the comma (for example, "tag:k8s-proxies\,tag:prod"). See https://github.com/helm/helm/issues/1556
+  defaultTags: "tag:k8s"
+  firewallMode: auto
+  # If defined, this proxy class will be used as the default proxy class for
+  # service and ingress resources that do not have a proxy class defined. It
+  # does not apply to Connector resources.
+  defaultProxyClass: ""
+
+# apiServerProxyConfig allows to configure whether the operator should expose
+# Kubernetes API server.
+# https://tailscale.com/kb/1437/kubernetes-operator-api-server-proxy
+apiServerProxyConfig:
+  # Set to "true" to create the ClusterRole permissions required for the API
+  # server proxy's auth mode. In auth mode, the API server proxy impersonates
+  # groups and users based on tailnet ACL grants. Required for ProxyGroups of
+  # type "kube-apiserver" running in auth mode.
+  allowImpersonation: "false" # "true", "false"
+
+  # If true or noauth, the operator will run an in-process API server proxy.
+  # You can deploy a ProxyGroup of type "kube-apiserver" to run a high
+  # availability set of API server proxies instead.
+  mode: "false" # "true", "false", "noauth"
+
+imagePullSecrets: []

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -32,3 +32,14 @@ resource "kubernetes_secret" "prod_cnpg_cluster_backup_credentials" {
     "ACCESS_SECRET_KEY" = var.r2_secret_access_key
   }
 }
+
+resource "kubernetes_secret" "tailscale_oauth_credentials" {
+  metadata {
+    name      = "operator-oauth"
+    namespace = "tailscale"
+  }
+  data = {
+    "client_id"     = var.tailscale_oauth_client_id
+    "client_secret" = var.tailscale_oauth_client_secret
+  }
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -86,3 +86,15 @@ variable "cloudflare_api_key" {
   type        = string
   sensitive   = true
 }
+
+variable "tailscale_oauth_client_id" {
+  description = "Tailscale OAuth Client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth Client Secret"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Configures Cilium to work with Tailscale by:

- Switching to native routing mode
- Enabling host namespace-only socketLB
- Setting up ingress controller and kube-proxy replacement