### PR TITLE
Restores Gramnuri applications and PostgreSQL DBs

### DIFF
--- a/argocd/apps/dev-gramnuri-api.yaml
+++ b/argocd/apps/dev-gramnuri-api.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-gramnuri-api
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igh9410/igh9410-infra.git
+    targetRevision: main
+    path: apps/gramnuri-api/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 5

--- a/argocd/apps/dev-gramnuri-web.yaml
+++ b/argocd/apps/dev-gramnuri-web.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-gramnuri-web
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igh9410/igh9410-infra.git
+    targetRevision: main
+    path: apps/gramnuri-web/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 5

--- a/argocd/apps/prod-gramnuri-api.yaml
+++ b/argocd/apps/prod-gramnuri-api.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-gramnuri-api
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igh9410/igh9410-infra.git
+    targetRevision: main
+    path: apps/gramnuri-api/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 5

--- a/argocd/apps/prod-gramnuri-web.yaml
+++ b/argocd/apps/prod-gramnuri-web.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-gramnuri-web
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igh9410/igh9410-infra.git
+    targetRevision: main
+    path: apps/gramnuri-web/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 5

--- a/argocd/infra-apps/dev-gramnuri-db.yaml
+++ b/argocd/infra-apps/dev-gramnuri-db.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-gramnuri-db
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://cloudnative-pg.github.io/charts
+      chart: cluster
+      targetRevision: "0.3.1"
+      helm:
+        releaseName: dev-gramnuri-db
+        valueFiles:
+          - $values/argocd/values/dev-gramnuri-db.yaml
+    - repoURL: https://github.com/igh9410/igh9410-infra.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cnpg-database
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+  revisionHistoryLimit: 10
+
+  # Ignore secrets that are managed outside of Git
+  ignoreDifferences:
+    # Ignore the database user credentials (created by the operator)
+    - group: ""
+      kind: Secret
+      name: cnpg-cluster-user-credentials
+      jsonPointers:
+        - /data
+    # Ignore the backup credentials (created by you)
+    - group: ""
+      kind: Secret
+      name: cnpg-cluster-backup-credentials
+      jsonPointers:
+        - /data

--- a/argocd/infra-apps/prod-gramnuri-db.yaml
+++ b/argocd/infra-apps/prod-gramnuri-db.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-gramnuri-db
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://cloudnative-pg.github.io/charts
+      chart: cluster
+      targetRevision: "0.3.1"
+      helm:
+        releaseName: prod-gramnuri-db
+        valueFiles:
+          - $values/argocd/values/prod-gramnuri-db.yaml
+    - repoURL: https://github.com/igh9410/igh9410-infra.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod-cnpg-database
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+  revisionHistoryLimit: 10
+
+  # Ignore secrets that are managed outside of Git
+  ignoreDifferences:
+    # Ignore the database user credentials (created by the operator)
+    - group: ""
+      kind: Secret
+      name: cnpg-cluster-user-credentials
+      jsonPointers:
+        - /data
+    # Ignore the backup credentials (created by you)
+    - group: ""
+      kind: Secret
+      name: cnpg-cluster-backup-credentials
+      jsonPointers:
+        - /data

--- a/argocd/values/dev-gramnuri-db-backup.yaml
+++ b/argocd/values/dev-gramnuri-db-backup.yaml
@@ -1,0 +1,537 @@
+# -- Override the name of the chart
+nameOverride: ""
+# -- Override the full name of the chart
+fullnameOverride: ""
+# -- Override the namespace of the chart
+namespaceOverride: ""
+
+###
+# -- Type of the CNPG database. Available types:
+# * `postgresql`
+# * `postgis`
+# * `timescaledb`
+type: postgresql
+
+version:
+  # -- PostgreSQL major version to use
+  postgresql: "17"
+  # -- If using TimescaleDB, specify the version
+  timescaledb: "2.15"
+  # -- If using PostGIS, specify the version
+  postgis: "3.4"
+
+###
+# -- Cluster mode of operation. Available modes:
+# * `standalone` - default mode. Creates new or updates an existing CNPG cluster.
+# * `replica` - Creates a replica cluster from an existing CNPG cluster. # TODO
+# * `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.
+mode: recovery
+
+recovery:
+  ##
+  # -- Available recovery methods:
+  # * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace.
+  # * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported).
+  # * `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to
+  #        migrate databases to CloudNativePG, even from outside Kubernetes.
+  # * `import` - Import one or more databases from an existing Postgres cluster.
+  method: object_store
+
+  ## -- Point in time recovery target. Specify one of the following:
+  pitrTarget:
+    # -- Time in RFC3339 format
+    time: ""
+
+  ##
+  # -- Backup Recovery Method
+  backupName: "" # Name of the backup to recover from. Required if method is `backup`.
+
+  ##
+  # -- The original cluster name when used in backups. Also known as serverName.
+  clusterName: "dev-cnpg-cluster"
+  # -- Name of the database used by the application. Default: `app`.
+  database: gramnuri_db
+  # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
+  owner: "gramnuri_db_owner"
+  # -- External cluster source name for recovery
+  source: "dev-cnpg-cluster"
+  # -- Overrides the provider specific default endpoint. Defaults to:
+  # S3: https://s3.<region>.amazonaws.com"
+  # Leave empty if using the default S3 endpoint
+  endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
+  # -- Specifies a CA bundle to validate a privately signed certificate.
+  endpointCA:
+    # -- Creates a secret with the given value if true, otherwise uses an existing secret.
+    create: false
+    name: ""
+    key: ""
+    value: ""
+  # -- Overrides the provider specific default path. Defaults to:
+  # S3: s3://<bucket><path>
+  # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
+  # Google: gs://<bucket><path>
+  destinationPath: "s3://igh9410-backup/postgres/dev"
+  # -- One of `s3`, `azure` or `google`
+  provider: s3
+  s3:
+    region: ""
+    bucket: ""
+    path: "/"
+    accessKey: ""
+    secretKey: ""
+    # -- Use the role based authentication without providing explicitly the keys
+    inheritFromIAMRole: false
+  azure:
+    path: "/"
+    connectionString: ""
+    storageAccount: ""
+    storageKey: ""
+    storageSasToken: ""
+    containerName: ""
+    serviceName: blob
+    inheritFromAzureAD: false
+  google:
+    path: "/"
+    bucket: ""
+    gkeEnvironment: false
+    applicationCredentials: ""
+  secret:
+    # -- Whether to create a secret for the backup credentials
+    create: false
+    # -- Name of the backup credentials secret
+    name: "cnpg-cluster-backup-credentials"
+
+  # See https://cloudnative-pg.io/documentation/1.22/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+  pgBaseBackup:
+    # -- Name of the database used by the application. Default: `app`.
+    database: app
+    # -- Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+    secret: ""
+    # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
+    owner: ""
+    source:
+      host: ""
+      port: 5432
+      username: ""
+      database: "app"
+      sslMode: "verify-full"
+      passwordSecret:
+        # -- Whether to create a secret for the password
+        create: false
+        # -- Name of the secret containing the password
+        name: ""
+        # -- The key in the secret containing the password
+        key: "password"
+        # -- The password value to use when creating the secret
+        value: ""
+      sslKeySecret:
+        name: ""
+        key: ""
+      sslCertSecret:
+        name: ""
+        key: ""
+      sslRootCertSecret:
+        name: ""
+        key: ""
+
+  # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-Import
+  import:
+    # -- One of `microservice` or `monolith.`
+    # See: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works
+    type: "microservice"
+    # -- Databases to import
+    databases: []
+    # -- Roles to import
+    roles: []
+    # -- List of SQL queries to be executed as a superuser in the application database right after is imported.
+    # To be used with extreme care. Only available in microservice type.
+    postImportApplicationSQL: []
+    # -- When set to true, only the pre-data and post-data sections of pg_restore are invoked, avoiding data import.
+    schemaOnly: false
+    # -- List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your
+    # own risk, as the operator does not validate their content. Be aware that certain options may conflict with the
+    # operator's intended functionality or design.
+    pgDumpExtraOptions: []
+    # -- List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at
+    # your own risk, as the operator does not validate their content. Be aware that certain options may conflict with the
+    # operator's intended functionality or design.
+    pgRestoreExtraOptions: []
+    source:
+      host: ""
+      port: 5432
+      username: ""
+      database: ""
+      sslMode: "verify-full"
+      passwordSecret:
+        # -- Whether to create a secret for the password
+        create: false
+        # -- Name of the secret containing the password
+        name: ""
+        # -- The key in the secret containing the password
+        key: "password"
+        # -- The password value to use when creating the secret
+        value: ""
+      sslKeySecret:
+        name: ""
+        key: ""
+      sslCertSecret:
+        name: ""
+        key: ""
+      sslRootCertSecret:
+        name: ""
+        key: ""
+
+cluster:
+  # -- Number of instances
+  instances: 2
+
+  # -- Name of the container image, supporting both tags (<image>:<tag>) and digests for deterministic and repeatable deployments:
+  # <image>:<tag>@sha256:<digestValue>
+  imageName: "" # Default value depends on type (postgresql/postgis/timescaledb)
+
+  # -- Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`
+  imageCatalogRef:
+    {}
+    # kind: ImageCatalog
+    # name: postgresql
+
+  # -- Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated.
+  # More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+  imagePullPolicy: IfNotPresent
+
+  # -- The list of pull secrets to be used to pull the images.
+  # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference
+  imagePullSecrets: []
+
+  storage:
+    size: 2Gi
+    storageClass: "local-path"
+
+  walStorage:
+    enabled: true
+    size: 100Mi
+    storageClass: ""
+
+  # -- The UID of the postgres user inside the image, defaults to 26
+  postgresUID: -1
+
+  # -- The GID of the postgres user inside the image, defaults to 26
+  postgresGID: -1
+
+  # -- Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/1.24/service_management/
+  services:
+    additional:
+      - selectorType: rw
+        updateStrategy: patch
+        serviceTemplate:
+          metadata:
+            name: "dev-gramnuri-db"
+            labels:
+              test-label: "true"
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: dev-gramnuri-db.local
+              tailscale.com/expose: "true"
+              tailscale.com/hostname: "dev-gramnuri-db"
+          spec:
+            type: LoadBalancer
+
+  # -- Resources requirements of every generated Pod.
+  # Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
+  # We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.
+  # See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/
+  resources:
+    requests:
+      memory: 100Mi
+
+  priorityClassName: ""
+
+  # -- Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been
+  # successfully updated. It can be switchover (default) or restart.
+  primaryUpdateMethod: switchover
+
+  # -- Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been
+  # successfully updated: it can be automated (unsupervised - default) or manual (supervised)
+  primaryUpdateStrategy: unsupervised
+
+  # -- The instances' log level, one of the following values: error, warning, info (default), debug, trace
+  logLevel: "info"
+
+  # -- Affinity/Anti-affinity rules for Pods.
+  # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration
+  affinity:
+    topologyKey: topology.kubernetes.io/zone
+
+  # -- The configuration for the CA and related certificates.
+  # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration
+  certificates: {}
+
+  # -- When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password.
+  # If the secret is not present, the operator will automatically create one.
+  # When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created,
+  # and then blank the password of the postgres user by setting it to NULL.
+  enableSuperuserAccess: true
+  superuserSecret: ""
+
+  # -- Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes
+  # See: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets
+  enablePDB: true
+
+  # -- This feature enables declarative management of existing roles, as well as the creation of new roles if they are not
+  # already present in the database.
+  # See: https://cloudnative-pg.io/documentation/current/declarative_role_management/
+  roles:
+    []
+    # - name: dante
+    #   ensure: present
+    #   comment: Dante Alighieri
+    #   login: true
+    #   superuser: false
+    #   inRoles:
+    #     - pg_monitor
+    #     - pg_signal_backend
+
+  monitoring:
+    # -- Whether to enable monitoring
+    enabled: true
+    podMonitor:
+      # -- Whether to enable the PodMonitor
+      enabled: true
+      # --The list of relabelings for the PodMonitor.
+      # Applied to samples before scraping.
+      relabelings: []
+      # -- The list of metric relabelings for the PodMonitor.
+      # Applied to samples before ingestion.
+      metricRelabelings: []
+    prometheusRule:
+      # -- Whether to enable the PrometheusRule automated alerts
+      enabled: true
+      # -- Exclude specified rules
+      excludeRules:
+        []
+        # - CNPGClusterZoneSpreadWarning
+    # -- Whether the default queries should be injected.
+    # Set it to true if you don't want to inject default queries into the cluster.
+    disableDefaultQueries: false
+    # -- Custom Prometheus metrics
+    # Will be stored in the ConfigMap
+    customQueries: []
+    #  - name: "pg_cache_hit_ratio"
+    #    query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+    #    metrics:
+    #      - datname:
+    #          usage: "LABEL"
+    #          description: "Name of the database"
+    #      - ratio:
+    #          usage: GAUGE
+    #          description: "Cache hit ratio"
+    # -- The list of secrets containing the custom queries
+    customQueriesSecret: []
+    #  - name: custom-queries-secret
+    #    key: custom-queries
+
+  postgresql:
+    # -- PostgreSQL configuration options (postgresql.conf)
+    parameters:
+      {}
+      # max_connections: 300
+    # -- Quorum-based Synchronous Replication
+    synchronous:
+      {}
+      # method: any
+      # number: 1
+    # -- PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)
+    pg_hba:
+      []
+      # - host all all 10.244.0.0/16 md5
+    # -- PostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)
+    pg_ident:
+      []
+      # - mymap   /^(.*)@mydomain\.com$      \1
+    # -- Lists of shared preload libraries to add to the default ones
+    shared_preload_libraries:
+      []
+      # - pgaudit
+    # -- PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)
+    ldap:
+      {}
+      # https://cloudnative-pg.io/documentation/1.24/postgresql_conf/#ldap-configuration
+      # server: 'openldap.default.svc.cluster.local'
+      # bindSearchAuth:
+      # baseDN: 'ou=org,dc=example,dc=com'
+      # bindDN: 'cn=admin,dc=example,dc=com'
+      # bindPassword:
+      # name: 'ldapBindPassword'
+      # key: 'data'
+      # searchAttribute: 'uid'
+
+  # -- BootstrapInitDB is the configuration of the bootstrap process when initdb is used.
+  # See: https://cloudnative-pg.io/documentation/current/bootstrap/
+  # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb
+  initdb:
+    {}
+    # database: app
+    # owner: "" # Defaults to the database name
+    # secret:
+    #   name: "" # Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+    # options: []
+    # encoding: UTF8
+    # postInitSQL:
+    #   - CREATE EXTENSION IF NOT EXISTS vector;
+    # postInitApplicationSQL: []
+    # postInitTemplateSQL: []
+
+  # -- Configure the metadata of the generated service account
+  serviceAccountTemplate: {}
+
+  additionalLabels: {}
+  annotations: {}
+externalClusters:
+  - name: dev-cnpg-cluster
+    barmanObjectStore:
+      destinationPath: "s3://igh9410-backup/postgres/dev"
+      endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-cluster-backup-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-cluster-backup-credentials
+          key: ACCESS_SECRET_KEY
+      wal:
+        retention: "7d"
+      data:
+        compression: gzip
+
+  # -- You need to configure backups manually, so backups are disabled by default.
+backups:
+  enabled: true
+
+  # -- Overrides the provider specific default endpoint. Defaults to:
+  # S3: https://s3.<region>.amazonaws.com"
+  endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com" # Leave empty if using the default S3 endpoint
+  # -- Specifies a CA bundle to validate a privately signed certificate.
+  endpointCA:
+    # -- Creates a secret with the given value if true, otherwise uses an existing secret.
+    create: false
+    name: ""
+    key: ""
+    value: ""
+
+  # -- Overrides the provider specific default path. Defaults to:
+  # S3: s3://<bucket><path>
+  # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
+  # Google: gs://<bucket><path>
+  destinationPath: "s3://igh9410-backup/dev/gramnuri-db"
+  # -- One of `s3`, `azure` or `google`
+  provider: s3
+  s3:
+    region: "apac"
+    bucket: "igh9410-backup"
+    path: "/dev/gramnuri-db"
+    accessKey: ""
+    secretKey: ""
+    # -- Use the role based authentication without providing explicitly the keys
+    inheritFromIAMRole: false
+  azure:
+    path: "/"
+    connectionString: ""
+    storageAccount: ""
+    storageKey: ""
+    storageSasToken: ""
+    containerName: ""
+    serviceName: blob
+    inheritFromAzureAD: false
+  google:
+    path: "/"
+    bucket: ""
+    gkeEnvironment: false
+    applicationCredentials: ""
+  secret:
+    # -- Whether to create a secret for the backup credentials
+    create: false
+    # -- Name of the backup credentials secret
+    name: "cnpg-cluster-backup-credentials"
+
+  wal:
+    # -- WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.
+    compression: gzip
+    # -- Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.
+    encryption: AES256
+    # -- Number of WAL files to be archived or restored in parallel.
+    maxParallel: 1
+  data:
+    # -- Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.
+    compression: gzip
+    # -- Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.
+    encryption: AES256
+    # -- Number of data files to be archived or restored in parallel.
+    jobs: 2
+
+  scheduledBackups:
+    # -- Scheduled backup name
+    - name: weekly-backup
+      # -- Schedule in cron format
+      schedule: "0 0 18 * * 0"
+      # -- Backup owner reference
+      backupOwnerReference: self
+      # -- Backup method, can be `barmanObjectStore` (default) or `volumeSnapshot`
+      method: barmanObjectStore
+  # -- Retention policy for backups
+  retentionPolicy: "30d"
+
+imageCatalog:
+  # -- Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.
+  create: true
+  # -- List of images to be provisioned in an image catalog.
+  images:
+    []
+    # - image: ghcr.io/your_repo/your_image:your_tag
+    #   major: 16
+
+# -- List of PgBouncer poolers
+poolers:
+  []
+  # -
+  #   # -- Pooler name
+  #   name: rw
+  #   # -- PgBouncer type of service to forward traffic to.
+  #   type: rw
+  #   # -- PgBouncer pooling mode
+  #   poolMode: transaction
+  #   # -- Number of PgBouncer instances
+  #   instances: 3
+  #   # -- PgBouncer configuration parameters
+  #   parameters:
+  #     max_client_conn: "1000"
+  #     default_pool_size: "25"
+  #   monitoring:
+  #     # -- Whether to enable monitoring
+  #     enabled: false
+  #     podMonitor:
+  #         # -- Whether to enable the PodMonitor
+  #       enabled: true
+  #   # -- Custom PgBouncer deployment template.
+  #   # Use to override image, specify resources, etc.
+  #   template: {}
+  # -
+  #   # -- Pooler name
+  #   name: ro
+  #   # -- PgBouncer type of service to forward traffic to.
+  #   type: ro
+  #   # -- PgBouncer pooling mode
+  #   poolMode: transaction
+  #   # -- Number of PgBouncer instances
+  #   instances: 3
+  #   # -- PgBouncer configuration parameters
+  #   parameters:
+  #     max_client_conn: "1000"
+  #     default_pool_size: "25"
+  #   monitoring:
+  #     # -- Whether to enable monitoring
+  #     enabled: false
+  #     podMonitor:
+  #         # -- Whether to enable the PodMonitor
+  #       enabled: true
+  #   # -- Custom PgBouncer deployment template.
+  #   # Use to override image, specify resources, etc.
+  #   template: {}


### PR DESCRIPTION
This pull request reintroduces the Gramnuri application stack and its associated PostgreSQL databases, reverting previous deletion actions.

### Summary
Reverts previous deletions to restore the entire Gramnuri application stack, including API, web, and their respective PostgreSQL databases across development and production environments.

### Impacted Areas
*   **ArgoCD Applications:** Adds new application definitions for `gramnuri-api` and `gramnuri-web` for both `dev` and `prod` environments.
*   **Database Infrastructure:** Reintroduces `dev-gramnuri-db` and `prod-gramnuri-db` using CloudNativePG, configured for object store recovery, automated weekly backups, and monitoring. The `dev-gramnuri-db` is specifically configured for recovery from an object store.
*   **Deployment Policies:** Configures distinct ArgoCD sync policies for `dev` (pruning enabled) and `prod` (pruning disabled) environments.