### PR TITLE
Refines CNPG database backup configurations

### DIFF
--- a/argocd/values/dev-gramnuri-db.yaml
+++ b/argocd/values/dev-gramnuri-db.yaml
@@ -70,7 +70,7 @@ recovery:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres/dev"
+  destinationPath: "s3://igh9410-backup/postgres"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -393,7 +393,7 @@ cluster:
 externalClusters:
   - name: dev-gramnuri-db-cluster
     barmanObjectStore:
-      destinationPath: "s3://igh9410-backup/postgres/dev"
+      destinationPath: "s3://igh9410-backup/postgres"
       endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
       s3Credentials:
         accessKeyId:
@@ -409,7 +409,8 @@ externalClusters:
 
   # -- You need to configure backups manually, so backups are disabled by default.
 backups:
-  enabled: true
+  # -- You need to configure backups manually, so backups are disabled by default.
+  enabled: false
 
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
@@ -426,7 +427,7 @@ backups:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres/dev"
+  destinationPath: "s3://igh9410-backup/postgres"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:

--- a/argocd/values/dev-gramnuri-db.yaml
+++ b/argocd/values/dev-gramnuri-db.yaml
@@ -70,7 +70,7 @@ recovery:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/dev/gramnuri-db"
+  destinationPath: "s3://igh9410-backup/postgres/dev"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -393,7 +393,7 @@ cluster:
 externalClusters:
   - name: dev-gramnuri-db-cluster
     barmanObjectStore:
-      destinationPath: "s3://igh9410-backup/dev/gramnuri-db"
+      destinationPath: "s3://igh9410-backup/postgres/dev"
       endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
       s3Credentials:
         accessKeyId:

--- a/argocd/values/prod-gramnuri-db.yaml
+++ b/argocd/values/prod-gramnuri-db.yaml
@@ -50,13 +50,13 @@ recovery:
 
   # -- Specifies a CA bundle to validate a privately signed certificate.
   # -- The original cluster name when used in backups. Also known as serverName.
-  clusterName: "prod-cnpg-cluster"
+  clusterName: "prod-gramnuri-db-cluster"
   # -- Name of the database used by the application. Default: `app`.
   database: gramnuri_db
   # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
   owner: "gramnuri_db_owner"
   # -- External cluster source name for recovery
-  source: "prod-cnpg-cluster"
+  source: "prod-gramnuri-db-cluster"
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
   # Leave empty if using the default S3 endpoint
@@ -392,7 +392,7 @@ cluster:
   annotations: {}
 
 externalClusters:
-  - name: prod-cnpg-cluster
+  - name: prod-gramnuri-db-cluster
     barmanObjectStore:
       destinationPath: "s3://igh9410-backup/postgres/prod"
       endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
@@ -427,7 +427,7 @@ backups:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/prod/gramnuri-db"
+  destinationPath: "s3://igh9410-backup/postgres/prod"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:

--- a/argocd/values/prod-gramnuri-db.yaml
+++ b/argocd/values/prod-gramnuri-db.yaml
@@ -71,7 +71,7 @@ recovery:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres/prod"
+  destinationPath: "s3://igh9410-backup/postgres"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -394,7 +394,7 @@ cluster:
 externalClusters:
   - name: prod-gramnuri-db-cluster
     barmanObjectStore:
-      destinationPath: "s3://igh9410-backup/postgres/prod"
+      destinationPath: "s3://igh9410-backup/postgres"
       endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
       s3Credentials:
         accessKeyId:
@@ -410,7 +410,7 @@ externalClusters:
 
 backups:
   # -- Backups enabled for production
-  enabled: true
+  enabled: false
 
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
@@ -427,7 +427,7 @@ backups:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres/prod"
+  destinationPath: "s3://igh9410-backup/postgres"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:


### PR DESCRIPTION
Normalizes backup and recovery destination paths for CNPG databases, improving consistency across development and production environments.

Temporarily disables backups, which addresses issues during initial database launches or restore operations. Also corrects cluster name references within the production configuration.

Relates to cnpg-db-restore