### PR TITLE
Configures CNPG database backups and recovery

### DIFF
--- a/argocd/values/dev-gramnuri-db.yaml
+++ b/argocd/values/dev-gramnuri-db.yaml
@@ -70,7 +70,7 @@ recovery:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres"
+  destinationPath: "s3://igh9410-backup/postgres/dev"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -393,7 +393,7 @@ cluster:
 externalClusters:
   - name: dev-gramnuri-db-cluster
     barmanObjectStore:
-      destinationPath: "s3://igh9410-backup/postgres"
+      destinationPath: "s3://igh9410-backup/postgres/dev"
       endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
       s3Credentials:
         accessKeyId:
@@ -409,8 +409,7 @@ externalClusters:
 
   # -- You need to configure backups manually, so backups are disabled by default.
 backups:
-  # -- You need to configure backups manually, so backups are disabled by default.
-  enabled: false
+  enabled: true
 
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
@@ -427,13 +426,13 @@ backups:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres"
+  destinationPath: "s3://igh9410-backup/dev/gramnuri-db"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
     region: "apac"
     bucket: "igh9410-backup"
-    path: "/postgres/dev"
+    path: "/dev/gramnuri-db"
     accessKey: ""
     secretKey: ""
     # -- Use the role based authentication without providing explicitly the keys

--- a/argocd/values/prod-gramnuri-db.yaml
+++ b/argocd/values/prod-gramnuri-db.yaml
@@ -184,15 +184,14 @@ recovery:
 
 cluster:
   # -- Number of instances (single instance due to hardware constraints on other nodes)
-  instances: 3
+  instances: 2
 
   # -- Name of the container image, supporting both tags (<image>:<tag>) and digests for deterministic and repeatable deployments:
   # <image>:<tag>@sha256:<digestValue>
   imageName: "" # Default value depends on type (postgresql/postgis/timescaledb)
 
   # -- Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`
-  imageCatalogRef:
-    {}
+  imageCatalogRef: {}
     # kind: ImageCatalog
     # name: postgresql
 
@@ -289,8 +288,7 @@ cluster:
   # -- This feature enables declarative management of existing roles, as well as the creation of new roles if they are not
   # already present in the database.
   # See: https://cloudnative-pg.io/documentation/current/declarative_role_management/
-  roles:
-    []
+  roles: []
     # - name: dante
     #   ensure: present
     #   comment: Dante Alighieri
@@ -316,8 +314,7 @@ cluster:
       # -- Whether to enable the PrometheusRule automated alerts
       enabled: true
       # -- Exclude specified rules
-      excludeRules:
-        []
+      excludeRules: []
         # - CNPGClusterZoneSpreadWarning
     # -- Whether the default queries should be injected.
     # Set it to true if you don't want to inject default queries into the cluster.
@@ -341,24 +338,19 @@ cluster:
 
   postgresql:
     # -- PostgreSQL configuration options (postgresql.conf)
-    parameters:
-      {}
+    parameters: {}
       # max_connections: 300
     # -- PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)
-    pg_hba:
-      []
+    pg_hba: []
       # - host all all 10.244.0.0/16 md5
     # -- PostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)
-    pg_ident:
-      []
+    pg_ident: []
       # - mymap   /^(.*)@mydomain\.com$      \1
     # -- Lists of shared preload libraries to add to the default ones
-    shared_preload_libraries:
-      []
+    shared_preload_libraries: []
       # - pgaudit
     # -- PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)
-    ldap:
-      {}
+    ldap: {}
       # https://cloudnative-pg.io/documentation/1.24/postgresql_conf/#ldap-configuration
       # server: 'openldap.default.svc.cluster.local'
       # bindSearchAuth:
@@ -372,8 +364,7 @@ cluster:
   # -- BootstrapInitDB is the configuration of the bootstrap process when initdb is used.
   # See: https://cloudnative-pg.io/documentation/current/bootstrap/
   # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb
-  initdb:
-    {}
+  initdb: {}
     # database: app
     # owner: "" # Defaults to the database name
     # secret:
@@ -486,14 +477,12 @@ imageCatalog:
   # -- Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.
   create: true
   # -- List of images to be provisioned in an image catalog.
-  images:
-    []
+  images: []
     # - image: ghcr.io/your_repo/your_image:your_tag
     #   major: 16
 
 # -- List of PgBouncer poolers
-poolers:
-  []
+poolers: []
   # -
   #   # -- Pooler name
   #   name: rw

--- a/argocd/values/prod-gramnuri-db.yaml
+++ b/argocd/values/prod-gramnuri-db.yaml
@@ -71,7 +71,7 @@ recovery:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres"
+  destinationPath: "s3://igh9410-backup/postgres/prod"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -394,7 +394,7 @@ cluster:
 externalClusters:
   - name: prod-gramnuri-db-cluster
     barmanObjectStore:
-      destinationPath: "s3://igh9410-backup/postgres"
+      destinationPath: "s3://igh9410-backup/postgres/prod"
       endpointURL: "https://c3b77c4aca2f20de101a1452ef946655.r2.cloudflarestorage.com"
       s3Credentials:
         accessKeyId:
@@ -410,7 +410,7 @@ externalClusters:
 
 backups:
   # -- Backups enabled for production
-  enabled: false
+  enabled: true
 
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
@@ -427,13 +427,13 @@ backups:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: "s3://igh9410-backup/postgres"
+  destinationPath: "s3://igh9410-backup/prod/gramnuri-db"
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
     region: "apac"
     bucket: "igh9410-backup"
-    path: "/postgres/prod"
+    path: "/prod/gramnuri-db"
     accessKey: ""
     secretKey: ""
     # -- Use the role based authentication without providing explicitly the keys


### PR DESCRIPTION
Enables and organizes database backups for both dev and prod environments.

Updates recovery and backup destination paths to be environment and service-specific, enhancing clarity and management of database restores.

Adjusts the replica count for the production `gramnuri-db` cluster to 2 instances.

Includes minor YAML formatting improvements for readability.