### PR TITLE
Integrates Argo Rollouts for gramnuri-web

### DIFF
--- a/apps/gramnuri-web/base/canary-service.yaml
+++ b/apps/gramnuri-web/base/canary-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gramnuri-web-canary
+spec:
+  ports:
+    - port: 80
+      targetPort: 3000
+  selector:
+    app: gramnuri-web
+  type: ClusterIP

--- a/apps/gramnuri-web/base/kustomization.yaml
+++ b/apps/gramnuri-web/base/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - rollout.yaml
+  - canary-service.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/apps/gramnuri-web/base/rollout.yaml
+++ b/apps/gramnuri-web/base/rollout.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: gramnuri-web
+  labels:
+    app: gramnuri-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gramnuri-web
+  template:
+    metadata:
+      labels:
+        app: gramnuri-web
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: gramnuri-web
+          image: ghcr.io/igh9410/gramnuri-web
+          ports:
+            - name: http
+              containerPort: 3000
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            failureThreshold: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            periodSeconds: 30
+      imagePullSecrets:
+        - name: ghcr-image-pull-secrets
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: gramnuri-web
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: gramnuri-web
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+  strategy:
+    canary:
+      canaryService: gramnuri-web-canary
+      stableService: gramnuri-web
+      trafficRouting:
+        gatewayAPI:
+          httpRoute: gramnuri-web-httproute
+      steps:
+        - setWeight: 50
+        - pause: { duration: 3m }

--- a/apps/gramnuri-web/overlays/dev/kustomization.yaml
+++ b/apps/gramnuri-web/overlays/dev/kustomization.yaml
@@ -4,6 +4,10 @@ namespace: dev
 resources:
   - ../../base
 patches:
+  - path: rollout-patch.yaml
+    target:
+      kind: Rollout
+      name: gramnuri-web
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/apps/gramnuri-web/overlays/dev/rollout-patch.yaml
+++ b/apps/gramnuri-web/overlays/dev/rollout-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: gramnuri-web
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: gramnuri-web
+          envFrom:
+            - secretRef:
+                name: gramnuri-client-secrets

--- a/apps/gramnuri-web/overlays/prod/kustomization.yaml
+++ b/apps/gramnuri-web/overlays/prod/kustomization.yaml
@@ -4,6 +4,10 @@ namespace: prod
 resources:
   - ../../base
 patches:
+  - path: rollout-patch.yaml
+    target:
+      kind: Rollout
+      name: gramnuri-web
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/apps/gramnuri-web/overlays/prod/rollout-patch.yaml
+++ b/apps/gramnuri-web/overlays/prod/rollout-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: gramnuri-web
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      steps:
+        - setWeight: 50
+        - pause: { duration: 5m }
+  template:
+    spec:
+      containers:
+        - name: gramnuri-web
+          resources:
+            requests:
+              cpu: 200m
+              memory: 500Mi
+            limits:
+              cpu: 200m
+              memory: 500Mi
+          envFrom:
+            - secretRef:
+                name: gramnuri-client-secrets

--- a/argocd/apps/dev-gramnuri-api.yaml
+++ b/argocd/apps/dev-gramnuri-api.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: dev
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: false
     syncOptions:
       - CreateNamespace=true

--- a/argocd/apps/dev-gramnuri-web.yaml
+++ b/argocd/apps/dev-gramnuri-web.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: dev
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: false
     syncOptions:
       - CreateNamespace=true

--- a/argocd/values/argo-rollouts.yaml
+++ b/argocd/values/argo-rollouts.yaml
@@ -259,9 +259,9 @@ controller:
 
   # -- Configures 3rd party traffic router plugins for controller
   ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
-  trafficRouterPlugins: []
-    # - name: "argoproj-labs/sample-nginx" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
-    #   location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+  trafficRouterPlugins:
+    - name: "argoproj-labs/gatewayAPI"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.13.0/gatewayapi-plugin-linux-amd64"
 
   # -- Whether to create the argo-rollouts-config ConfigMap. Set to false when running multiple
   # controller instances in the same namespace (e.g. with different --instance-id values) to


### PR DESCRIPTION
Enables advanced deployment capabilities for the `gramnuri-web` application by migrating from a standard Kubernetes Deployment to an Argo Rollout resource. This change introduces canary deployment strategies to enhance reliability and reduce risk during application updates.

Key changes include:
-   Adds a new Argo Rollout resource for `gramnuri-web`, configured with a canary deployment strategy.
-   Introduces a dedicated canary Service and leverages Gateway API for traffic management during rollouts.
-   Updates Kustomize configurations to include the new Rollout and canary Service, along with environment-specific patches for development and production (e.g., replica counts, resource allocations, secret handling, and canary pause durations).
-   Configures the Argo Rollouts controller to install and utilize the Gateway API traffic router plugin, enabling seamless integration with Gateway API for traffic shifting.
-   Adjusts Argo CD sync policies for relevant applications to set `prune: false`, providing a safer transition path and preventing unintended resource deletions.